### PR TITLE
renovate automergeのススメ

### DIFF
--- a/.github/workflows/validate-renovate.yml
+++ b/.github/workflows/validate-renovate.yml
@@ -1,0 +1,22 @@
+name: validate renovate
+
+on:
+  pull_request:
+    paths:
+      - 'renovate.json'
+      - '.github/workflows/validate-renovate.yml'
+
+jobs:
+  validate-renovate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+
+      - name: install
+        run: |
+          npm install -g renovate
+      - name: validate
+        run: |
+          renovate-config-validator

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["config:base"],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    }
+  ]
+}


### PR DESCRIPTION
- フロントエンドはめちゃくちゃパッケージアップデートがありがち(なのでdependabotが使われている)
- #34 でCIが入った
- ので，CIが通ったらdependabotのPRを自動でマージ(・デプロイ)できるとうれしい
- dependabot自体にはautomerge機能はなさげ
- なので`automerge`というラベルがついたらマージするGitHub Appや，GitHub Actionsで頑張るテクがあるっぽい
- が，renovateだと一発でできて楽
- あとmonorepo系のやつがrenovateだと1つのPRにまとまってうれしい
- のでdependabotやめてrenovate使ってautomergeで優勝してはどうか