### PR TITLE
prettierがTypeScriptファイルしかフォーマットしないようにする

### DIFF
--- a/.github/workflows/prettier-format.yml
+++ b/.github/workflows/prettier-format.yml
@@ -26,5 +26,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           only_changed: True
-          prettier_options: --write **/*.{json,js,ts,scss}
+          prettier_options: --write **/*.ts
           commit_message: "Format by prettier"


### PR DESCRIPTION
close #96 