### PR TITLE
Update prettier_action to 4.1.1(manually)

### DIFF
--- a/.github/workflows/prettier-format.yml
+++ b/.github/workflows/prettier-format.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
 
       - name: prettier
-        uses: creyD/prettier_action@v4.0
+        uses: creyD/prettier_action@v4.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
`4.1.1`がlatestで，`4.1`->`4.1.1`もbug fixだしどうせRenovate来てくれないので`4.1.1`に上げちゃうか

_Originally posted by @sksat in https://github.com/jurliyuuri/cerke_online_alpha/issues/177#issuecomment-991902849_