### PR TITLE
フレンド対戦機能でSecureContextでない場合にnavigator.clipboardが存在しないことによるエラーを修正など

### DIFF
--- a/public/friend_make_room.html
+++ b/public/friend_make_room.html
@@ -5,11 +5,13 @@
     <title>友人戦待機部屋</title>
     <link href="pending.css" rel="stylesheet" type="text/css">
     <script>
-        function copy_url() {
+        function select_or_copy_url() {
             const textbox = document.getElementById("url");
             textbox.select();
             textbox.setSelectionRange(0, 99999);
-            navigator.clipboard.writeText(textbox.value);
+            if (isSecureContext) {
+                navigator.clipboard.writeText(textbox.value);
+            }
         }
     </script>
 </head>
@@ -19,7 +21,8 @@
         <div id="container">
             <div style="margin: 0 auto; text-align: center; font-size: 30px;">
                 対戦参加用 URL (これをなんらかの手段で友達に送って下さい)<br>
-                <input type="text" id="url" readonly><input type="button" value="URLをコピーする" onclick="copy_url()">
+                <input type="text" id="url" readonly><input type="button" disabled id="url-button" value="URLを生成中..."
+                    onclick="select_or_copy_url()">
             </div>
             <img src="image/piece_img/官字/upright/bmun.png" id="cancel_button" style="cursor: pointer">
 

--- a/src/friend_make_room.ts
+++ b/src/friend_make_room.ts
@@ -23,6 +23,9 @@ function make_room() {
 		const url_segments = location.href.split("/");
 		url_segments[url_segments.length - 1] = `friend_join_room.html?room_id=${o.room_id}&room_key=${o.room_key}`;
 		(document.getElementById("url") as HTMLInputElement).value = url_segments.join("/");
+		const url_button = document.getElementById("url-button") as HTMLInputElement;
+		url_button.disabled = false;
+		url_button.value = isSecureContext ? "URLをコピーする" : "全選択";
 		let res: RetFriendPoll = await sendPoll<RetFriendPoll>(
 			o.session_token as SessionToken,
 			(a) => a,


### PR DESCRIPTION
* navigator.clipboardはSecureContext(https or localhostなど)でないと使えないので、使えない時はクリップボードにコピーは行わずURLを全選択するだけにした
* ページをロードしてから、フレンド対戦URLがサーバーから返されるまでの時間は生成中であることをわかるようにした


https://discord.com/channels/666311190133342228/668122592720322570/958290179121098813